### PR TITLE
Fix Ruby color scheme

### DIFF
--- a/src/main/resources/META-INF/alabaster-bg.xml
+++ b/src/main/resources/META-INF/alabaster-bg.xml
@@ -754,7 +754,10 @@
             <value />
         </option>
         <option name="RUBY_CONSTANT_DECLARATION">
-            <value />
+            <value>
+                <option name="FOREGROUND" value="3e7e" />
+                <option name="BACKGROUND" value="dbf1ff" />
+            </value>
         </option>
         <option name="RUBY_HASH_ASSOC">
             <value />
@@ -774,6 +777,9 @@
                 <option name="BACKGROUND" value="dbf1ff" />
             </value>
         </option>
+        <option name="RUBY_PARAMDEF_CALL">
+            <value />
+        </option>
         <option name="RUBY_PARAMETER_ID">
             <value />
         </option>
@@ -782,6 +788,9 @@
                 <option name="FOREGROUND" value="64200" />
                 <option name="BACKGROUND" value="c0ecaa" />
             </value>
+        </option>
+        <option name="RUBY_SPECIFIC_CALL">
+            <value />
         </option>
         <option name="RUNTIME_ERROR">
             <value>

--- a/src/main/resources/META-INF/alabaster-dark.xml
+++ b/src/main/resources/META-INF/alabaster-dark.xml
@@ -360,6 +360,59 @@
     <option name="PY.SELF_PARAMETER">
       <value />
     </option>
+    <option name="RUBY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="ffc66d" />
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT">
+      <value />
+    </option>
+    <option name="RUBY_CONSTANT_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="6086be" />
+      </value>
+    </option>
+    <option name="RUBY_GVAR" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
+    <option name="RUBY_HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="6a8759" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="RUBY_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="6a8759" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_LOCAL_VAR_ID">
+      <value />
+    </option>
+    <option name="RUBY_METHOD_NAME">
+      <value>
+        <option name="FOREGROUND" value="6086be" />
+      </value>
+    </option>
+    <option name="RUBY_PARAMDEF_CALL">
+      <value />
+    </option>
+    <option name="RUBY_PARAMETER_ID">
+      <value />
+    </option>
+    <option name="RUBY_REGEXP">
+      <value>
+        <option name="FOREGROUND" value="95cb82" />
+      </value>
+    </option>
+    <option name="RUBY_SPECIFIC_CALL">
+      <value />
+    </option>
+    <option name="RUBY_SYMBOL">
+      <value />
+    </option>
+    <option name="RUBY_WORDS" baseAttributes="DEFAULT_STRING" />
     <option name="REGEXP.BRACES" baseAttributes="DEFAULT_BRACES" />
     <option name="REGEXP.BRACKETS" baseAttributes="DEFAULT_BRACKETS" />
     <option name="REGEXP.CHAR_CLASS" baseAttributes="DEFAULT_ENTITY" />

--- a/src/main/resources/META-INF/alabaster.xml
+++ b/src/main/resources/META-INF/alabaster.xml
@@ -366,6 +366,57 @@
     <option name="PY.SELF_PARAMETER">
       <value />
     </option>
+    <option name="RUBY_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="aa3731" />
+      </value>
+    </option>
+    <option name="RUBY_CONSTANT_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="325cc0" />
+      </value>
+    </option>
+    <option name="RUBY_HASH_ASSOC" baseAttributes="DEFAULT_OPERATION_SIGN" />
+    <option name="RUBY_HEREDOC_CONTENT">
+      <value>
+        <option name="FOREGROUND" value="448c27" />
+        <option name="EFFECT_TYPE" value="5" />
+      </value>
+    </option>
+    <option name="RUBY_HEREDOC_ID">
+      <value>
+        <option name="FOREGROUND" value="448c27" />
+        <option name="FONT_TYPE" value="1" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_LOCAL_VAR_ID" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
+    <option name="RUBY_METHOD_NAME">
+      <value>
+        <option name="FOREGROUND" value="325cc0" />
+      </value>
+    </option>
+    <option name="RUBY_NTH_REF">
+      <value>
+        <option name="FOREGROUND" value="7a3e9d" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_PARAMDEF_CALL">
+      <value />
+    </option>
+    <option name="RUBY_PARAMETER_ID">
+      <value />
+    </option>
+    <option name="RUBY_REGEXP">
+      <value>
+        <option name="FOREGROUND" value="448c27" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="RUBY_SPECIFIC_CALL">
+      <value />
+    </option>
     <option name="REGEXP.META">
       <value />
     </option>

--- a/src/test/testData/sample.rb
+++ b/src/test/testData/sample.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+str = 'hello' # strings are highlighted
+
+puts str
+
+num = 5 # numbers are highlighted
+constt = true # no way to highlight only boolean constants
+
+# All callable variables should be highlighted during declaration, but not during invocation.
+
+def hello(some_stuff) # highlighted
+  def hello05 # highlighted
+  end
+
+  hello05() # should not be highlighted
+
+  return some_stuff + ' from a function.'
+end
+
+hello('hello') # should not be highlighted
+
+hello2 = lambda do # no way to highlight lambda declarations
+end
+
+hello2.call('') # should not be highlighted
+
+hello3 = -> {
+} # no way to highlight short lambda declarations
+
+hello3.call # should not be highlighted
+
+def generator(i) # highlighted
+  Enumerator.new do |yielder|
+    yielder << i
+    yielder << (i + 10)
+  end
+end
+
+generator(nil) # should not be highlighted
+
+obj = {
+  field_func: -> {
+  } # no way to highlight lambda declarations
+}
+
+class Rectangle # highlighted
+  def initialize(height, width) # highlighted
+    @height = height
+    @width = width
+  end
+
+  def some_method # highlighted
+  end
+end
+
+rect = Rectangle.new(1, 2) # should not be highlighted
+
+rect.some_method # should not be highlighted
+
+Rectangle2 = Class.new do # highlighted
+  def initialize(height, width) # highlighted
+    @height = height
+    @width = width
+  end
+end
+
+rect2 = Rectangle2.new(1, 2) # should not be highlighted


### PR DESCRIPTION
Made a best effort to fix the color scheme for Ruby.

Alabaster BG
<img width="400" alt="alabaster-bg-ruby" src="https://github.com/user-attachments/assets/19c8d98a-d09b-4285-93f9-33ea8d1d5815" />


Alabaster
<img width="400" alt="alabaster-ruby" src="https://github.com/user-attachments/assets/7857a4f4-1570-4f71-ac5b-aada7558465d" />


Alabaster Dark
<img width="400" alt="alabaster-dark-ruby" src="https://github.com/user-attachments/assets/8d994295-147b-43c4-89a5-3c1e2418cad8" />
