### PR TITLE
Add color for Ruby symbols

### DIFF
--- a/src/main/resources/META-INF/alabaster-bg.xml
+++ b/src/main/resources/META-INF/alabaster-bg.xml
@@ -762,6 +762,9 @@
         <option name="RUBY_HASH_ASSOC">
             <value />
         </option>
+        <option name="RUBY_HASH_KEY">
+            <value />
+        </option>
         <option name="RUBY_HEREDOC_CONTENT">
             <value>
                 <option name="FOREGROUND" value="64200" />
@@ -791,6 +794,11 @@
         </option>
         <option name="RUBY_SPECIFIC_CALL">
             <value />
+        </option>
+        <option name="RUBY_SYMBOL">
+            <value>
+                <option name="FOREGROUND" value="7a3e9d" />
+            </value>
         </option>
         <option name="RUNTIME_ERROR">
             <value>

--- a/src/main/resources/META-INF/alabaster-dark.xml
+++ b/src/main/resources/META-INF/alabaster-dark.xml
@@ -374,6 +374,9 @@
       </value>
     </option>
     <option name="RUBY_GVAR" baseAttributes="DEFAULT_GLOBAL_VARIABLE" />
+    <option name="RUBY_HASH_KEY">
+      <value />
+    </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="6a8759" />
@@ -410,7 +413,9 @@
       <value />
     </option>
     <option name="RUBY_SYMBOL">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="9876aa" />
+      </value>
     </option>
     <option name="RUBY_WORDS" baseAttributes="DEFAULT_STRING" />
     <option name="REGEXP.BRACES" baseAttributes="DEFAULT_BRACES" />

--- a/src/main/resources/META-INF/alabaster-dark.xml
+++ b/src/main/resources/META-INF/alabaster-dark.xml
@@ -404,11 +404,7 @@
     <option name="RUBY_PARAMETER_ID">
       <value />
     </option>
-    <option name="RUBY_REGEXP">
-      <value>
-        <option name="FOREGROUND" value="95cb82" />
-      </value>
-    </option>
+    <option name="RUBY_REGEXP" baseAttributes="DEFAULT_STRING" />
     <option name="RUBY_SPECIFIC_CALL">
       <value />
     </option>

--- a/src/main/resources/META-INF/alabaster.xml
+++ b/src/main/resources/META-INF/alabaster.xml
@@ -377,6 +377,9 @@
       </value>
     </option>
     <option name="RUBY_HASH_ASSOC" baseAttributes="DEFAULT_OPERATION_SIGN" />
+    <option name="RUBY_HASH_KEY">
+      <value />
+    </option>
     <option name="RUBY_HEREDOC_CONTENT">
       <value>
         <option name="FOREGROUND" value="448c27" />
@@ -416,6 +419,11 @@
     </option>
     <option name="RUBY_SPECIFIC_CALL">
       <value />
+    </option>
+    <option name="RUBY_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="7a3e9d" />
+      </value>
     </option>
     <option name="REGEXP.META">
       <value />


### PR DESCRIPTION
* Use a constant color for symbols.
* Derive the Ruby regexp color from the base string, similar to the JS regexp.