### PR TITLE
Unbreak IdeaVim WhichKey plugin

### DIFF
--- a/src/main/resources/META-INF/alabaster-bg.xml
+++ b/src/main/resources/META-INF/alabaster-bg.xml
@@ -301,7 +301,9 @@
             </value>
         </option>
         <option name="DEFAULT_KEYWORD">
-            <value />
+            <value>
+                <option name="FOREGROUND" value="0" />
+            </value>
         </option>
         <option name="DEFAULT_LABEL">
             <value>

--- a/src/main/resources/META-INF/alabaster-dark.xml
+++ b/src/main/resources/META-INF/alabaster-dark.xml
@@ -137,7 +137,9 @@
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="a9b7c6" />
+      </value>
     </option>
     <option name="DEFAULT_LABEL">
       <value />

--- a/src/main/resources/META-INF/alabaster.xml
+++ b/src/main/resources/META-INF/alabaster.xml
@@ -135,7 +135,9 @@
       </value>
     </option>
     <option name="DEFAULT_KEYWORD">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="0" />
+      </value>
     </option>
     <option name="DEFAULT_LABEL">
       <value />


### PR DESCRIPTION
## Problem 
IdeaVim WhichKey crashes with `java.lang.NullPointerException: getForegroundColor(...) must not be null`.
https://github.com/TheBlob42/idea-which-key/blob/main/src/main/kotlin/eu/theblob42/idea/whichkey/config/FormatConfig.kt#L21

Stacktrace
```java
java.lang.NullPointerException: getForegroundColor(...) must not be null
	at eu.theblob42.idea.whichkey.config.FormatConfig.getDefaultKeywordColor(FormatConfig.kt:21)
	at eu.theblob42.idea.whichkey.config.FormatConfig.getDescPrefixColor(FormatConfig.kt:89)
	at eu.theblob42.idea.whichkey.config.FormatConfig.formatMappingEntry(FormatConfig.kt:121)
	at eu.theblob42.idea.whichkey.config.PopupConfig.showPopup(PopupConfig.kt:101)
	at eu.theblob42.idea.whichkey.WhichKeyTypeActionHandler.beforeExecute(WhichKeyTypeActionHandler.kt:66)
	...
```

## Solution

Set up the default keyword color

P.S. I'm open to suggestions on how this can be done in the right way.

<img width="1493" alt="SCR-20250428-pmgj" src="https://github.com/user-attachments/assets/79fd59f9-8578-4c5d-b1d8-1d49118ac400" />

