### PR TITLE
Fixing some UnsupportedOperationExceptions in the plugin.

### DIFF
--- a/src/main/clojure/com/vlnabatov/alabaster/clojure_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/clojure_annotator.clj
@@ -23,6 +23,7 @@
 (defn is-clojure-lang-ns-call [^ClojurePsiElement e] ())
 
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]

--- a/src/main/clojure/com/vlnabatov/alabaster/factory.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/factory.clj
@@ -53,6 +53,7 @@
 
 (defn -uiSettingsChanged [_this _] (patch-options))
 (defn -globalSchemeChange [_this _] (patch-options))
+(defn -isDumbAware [_this] true)
 
 (defn handler
   [request project]

--- a/src/main/clojure/com/vlnabatov/alabaster/go_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/go_annotator.clj
@@ -17,6 +17,7 @@
               :prefix     "-"))
 
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]

--- a/src/main/clojure/com/vlnabatov/alabaster/java_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/java_annotator.clj
@@ -12,6 +12,7 @@
               :name       com.vlnabatov.alabaster.extensions.annotation.JavaAnnotator
               :prefix     "-"))
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]

--- a/src/main/clojure/com/vlnabatov/alabaster/kotlin_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/kotlin_annotator.clj
@@ -11,6 +11,7 @@
               :prefix     "-"))
 
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]

--- a/src/main/clojure/com/vlnabatov/alabaster/scala_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/scala_annotator.clj
@@ -11,6 +11,7 @@
               :name       com.vlnabatov.alabaster.extensions.annotation.ScalaAnnotator
               :prefix     "-"))
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]

--- a/src/main/clojure/com/vlnabatov/alabaster/xml_annotator.clj
+++ b/src/main/clojure/com/vlnabatov/alabaster/xml_annotator.clj
@@ -9,6 +9,7 @@
               :name       com.vlnabatov.alabaster.extensions.annotation.XMLAnnotator
               :prefix     "-"))
 
+(defn -isDumbAware [_this] false)
 
 (defn -annotate
   [_ ^PsiElement element ^AnnotationHolder holder]


### PR DESCRIPTION
Apparently Clojure re-generates default methods with methods that throw UOE.

This provides some sensible implementation of these methods preventing a plugin from throwing exception during run.